### PR TITLE
Fix consumedUnits type

### DIFF
--- a/type_source.go
+++ b/type_source.go
@@ -65,11 +65,11 @@ type ConnectorAttributes struct {
 	PageSize                string      `json:"pageSize,omitempty"`
 	AuthURL                 interface{} `json:"authURL,omitempty"`
 	SubscribedSkus          []struct {
-		ConsumedUnits int `json:"consumedUnits"`
+		ConsumedUnits float32 `json:"consumedUnits"`
 		PrepaidUnits  struct {
-			Warning   int `json:"warning"`
-			Enabled   int `json:"enabled"`
-			Suspended int `json:"suspended"`
+			Warning   float32 `json:"warning"`
+			Enabled   float32 `json:"enabled"`
+			Suspended float32 `json:"suspended"`
 		} `json:"prepaidUnits"`
 		SkuPartNumber    string `json:"skuPartNumber"`
 		CapabilityStatus string `json:"capabilityStatus"`


### PR DESCRIPTION
When init with identitynow_source, I got the following parsing error, this PR would fix that

```
2021-06-09T22:12:55.573+0700 [DEBUG] plugin: plugin exited
Error: json: cannot unmarshal number 6.0 into Go struct field .connectorAttributes.subscribedSkus.consumedUnits of type int

  on main.tf line 1, in data "identitynow_source" "aad_source":
  1: data "identitynow_source" "aad_source" {
```